### PR TITLE
[Fix] Align on names for "info" command

### DIFF
--- a/src/connector-cli/src/commands/info.ts
+++ b/src/connector-cli/src/commands/info.ts
@@ -77,12 +77,12 @@ export async function runGetInfo(
       console.table(formattedCapabilities, ['capability']);
     }
 
-    // Connector settings
+    // Connector query options
     const formattedConfigurationOptions =
       connectorCodeConfig.configurationOptions;
 
     if (formattedConfigurationOptions.length === 0) {
-      info('Settings: Connector does not have any settings defined');
+      info('Query options: Connector does not have any query options defined');
     } else {
       info('Settings...');
       console.table(formattedConfigurationOptions, [
@@ -93,10 +93,10 @@ export async function runGetInfo(
     }
   }
 
-  // Runtime options
+  // Runtime settings
   if (Object.values(connectorConfig.options).length === 0) {
     info(
-      'Runtime options: Connector does not have any runtime options defined'
+      'Runtime settings: Connector does not have any runtime settings defined'
     );
   } else {
     const formattedOptinos = Object.entries(connectorConfig.options).map(
@@ -110,7 +110,7 @@ export async function runGetInfo(
       }
     );
 
-    info('Runtime options...');
+    info('Runtime settings...');
     console.table(formattedOptinos, ['name', 'required', 'default']);
   }
 

--- a/src/connector-cli/src/commands/info.ts
+++ b/src/connector-cli/src/commands/info.ts
@@ -84,7 +84,7 @@ export async function runGetInfo(
     if (formattedConfigurationOptions.length === 0) {
       info('Query options: Connector does not have any query options defined');
     } else {
-      info('Settings...');
+      info('Query options...');
       console.table(formattedConfigurationOptions, [
         'type',
         'name',

--- a/src/connector-cli/src/commands/init/templates.ts
+++ b/src/connector-cli/src/commands/init/templates.ts
@@ -54,6 +54,13 @@ export const getTsConfig = () => ({
 const mediaConnectorFileContent = `import { Connector, Media } from "@chili-publish/studio-connectors";
 
 export default class MyConnector implements Media.MediaConnector {
+
+  private runtime: Connector.ConnectorRuntimeContext;
+
+  constructor(runtime: Connector.ConnectorRuntimeContext) {
+    this.runtime = runtime;
+  }
+    
   query(
     options: Connector.QueryOptions,
     context: Connector.Dictionary


### PR DESCRIPTION
In this PR we:
- fix `names` for the information outputted by `info` command 
- update template for `connector.ts` file for initialise command - to include `runtime` as class field