### PR TITLE
[Feat][WRS-1643] Introduce --dry-run-out option for "set-auth" and "publish" commands

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,22 +1,21 @@
 # workflow to run both yarn && yarn build in the repo when pr is created
 name: Build PR
 on: [pull_request]
+env:
+  NODE_VERSION: 20
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       cli_changed: ${{ steps.git_diff.outputs.cli_changed }}
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Fetches all history for all branches and tags
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
         run: yarn
       - name: Build CLI

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -5,22 +5,23 @@ on:
   push:
     branches:
       - main
-
+    paths:
+      - 'src/connectors/**' # Only trigger when files under the cli package have changed
+      - 'scripts/publish.js'
+env:
+  NODE_VERSION: 20
 jobs:
   build-and-publish:
     # checkout the repo
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
         run: yarn
 
@@ -58,7 +59,7 @@ jobs:
           echo "Changed directories: $CHANGED_CONNECTOR"
           echo "CHANGED_CONNECTOR=$CHANGED_CONNECTOR" >> $GITHUB_ENV
 
-      - name: Build Cli
+      - name: Build CLI
         run: yarn run build-cli
 
       - name: Build and Publish connectors

--- a/.github/workflows/publish-cli-release.yml
+++ b/.github/workflows/publish-cli-release.yml
@@ -2,20 +2,19 @@ name: Publish CLI to NPM (Release)
 on:
   release:
     types: [published]
+env:
+  NODE_VERSION: 20
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PACKAGE_SECRET }}
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Check version correctness
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -34,11 +33,11 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Build
-        run: yarn workspace @chili-publish/connector-cli run build
-      - name: Use Node.js ${{ matrix.node-version }}
+        run: yarn run build-cli
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           scope: '@chili-publish'
       - name: Publish

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -7,25 +7,23 @@ on:
     paths:
       - 'src/connector-cli/**' # Only trigger when files under the cli package have changed
       - '.github/workflows/publish-cli.yml'
-
+env:
+  NODE_VERSION: 20
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PACKAGE_SECRET }}
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies
         run: yarn
       - name: Build
-        run: yarn workspace @chili-publish/connector-cli run build
+        run: yarn run build-cli
       - name: Bump version
         uses: phips28/gh-action-bump-version@v11.0.7
         env:
@@ -35,10 +33,10 @@ jobs:
         with:
           version-type: 'prerelease'
           commit-message: 'CI: bumps version to {{version}} [skip ci]'
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://npm.pkg.github.com'
           scope: '@chili-publish'
       - name: Publish

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "studio-connector-contrib",
+  "name": "studio-connector-framework",
   "private": true,
   "version": "1.0.1",
   "author": "CHILI publish",

--- a/src/connector-cli/src/commands/new/steps/getProjectParams.ts
+++ b/src/connector-cli/src/commands/new/steps/getProjectParams.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { ConnectorType } from '../../../core/types';
 
 import { input, select } from '@inquirer/prompts';
+import { error } from 'console';
 import { NewCommandOptions } from '../types';
 
 type ProjectParams = [
@@ -19,16 +20,23 @@ const packageNameRegex =
 export async function getProjectParams(
   options: NewCommandOptions & { projectName?: string }
 ): Promise<ProjectParams> {
-  const projectName = await input({
-    message: "Connector's project name",
-    default: options.projectName || 'connector',
-    validate: (value) => {
-      return (
-        packageNameRegex.test(value) ||
-        'Invalid project name. The name must be a valid npm package name'
-      );
-    },
-  });
+  let inputProjectName = options.projectName;
+  if (inputProjectName && !packageNameRegex.test(inputProjectName)) {
+    error('Invalid project name. The name must be a valid npm package name');
+    inputProjectName = undefined;
+  }
+  const projectName =
+    inputProjectName ||
+    (await input({
+      message: "Connector's project name",
+      default: 'connector',
+      validate: (value) => {
+        return (
+          packageNameRegex.test(value) ||
+          'Invalid project name. The name must be a valid npm package name'
+        );
+      },
+    }));
 
   const type =
     options.type ||

--- a/src/connector-cli/src/commands/new/steps/getProjectParams.ts
+++ b/src/connector-cli/src/commands/new/steps/getProjectParams.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { ConnectorType } from '../../../core/types';
 
 import { input, select } from '@inquirer/prompts';
-import { error } from 'console';
+import { error } from '../../../core';
 import { NewCommandOptions } from '../types';
 
 type ProjectParams = [

--- a/src/connector-cli/src/commands/publish/index.ts
+++ b/src/connector-cli/src/commands/publish/index.ts
@@ -2,6 +2,7 @@ import dot from 'dot-object';
 import { buildRequestUrl } from '../../common/build-request-url';
 import {
   info,
+  isDryRun,
   readConnectorConfig,
   startCommand,
   validateRuntimeOptions,
@@ -33,7 +34,9 @@ export async function runPublish(
 ): Promise<void> {
   startCommand('publish', { projectPath, options });
 
-  const accessToken = await readAccessToken(options.tenant);
+  const accessToken = isDryRun()
+    ? 'Bearer Token'
+    : await readAccessToken(options.tenant);
 
   // store all options as vars
   const {

--- a/src/connector-cli/src/commands/set-auth/steps/set-authentication.ts
+++ b/src/connector-cli/src/commands/set-auth/steps/set-authentication.ts
@@ -1,4 +1,4 @@
-import { httpErrorHandler, info, isDryRun, verbose } from '../../../core';
+import { httpErrorHandler, isDryRun, logRequest } from '../../../core';
 import { APIConnectorAuthentication } from '../types';
 
 export async function setAuthentication(
@@ -6,18 +6,11 @@ export async function setAuthentication(
   payload: APIConnectorAuthentication,
   token: string
 ) {
-  const msg = `Deploying connector:\n requestUrl: "${requestUrl}\n payload:${JSON.stringify(
-    payload,
-    null,
-    2
-  )}\n`;
+  logRequest(requestUrl, payload);
 
   if (isDryRun()) {
-    info(msg);
     return;
   }
-
-  verbose(msg);
 
   const res = await fetch(requestUrl, {
     method: 'PUT',

--- a/src/connector-cli/src/common/get-connector.ts
+++ b/src/connector-cli/src/common/get-connector.ts
@@ -1,4 +1,4 @@
-import { httpErrorHandler, verbose, warn } from '../core';
+import { httpErrorHandler, logRequest, verbose, warn } from '../core';
 import { ExecutionError } from '../core/types';
 import { selectAvailableConnector } from './select-available-connector';
 
@@ -20,9 +20,8 @@ export async function getConnectorById(
 ): Promise<EnvironmentConnector> {
   const getConnectorEnpdoint = `${request.baseUrl}/${request.connectorId}`;
 
-  verbose(
-    `Checking connector's existing with id ${request.connectorId} -> ${getConnectorEnpdoint}`
-  );
+  logRequest(getConnectorEnpdoint);
+
   const res = await fetch(getConnectorEnpdoint, {
     headers: {
       Authorization: request.token,

--- a/src/connector-cli/src/common/select-available-connector.ts
+++ b/src/connector-cli/src/common/select-available-connector.ts
@@ -1,12 +1,15 @@
 import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
-import { httpErrorHandler, info, warn } from '../core';
+import { httpErrorHandler, info, logRequest, warn } from '../core';
 
 export async function selectAvailableConnector(
   connectorEndpointBaseUrl: string,
   token: string
 ): Promise<string> {
   info(`Requesting the list of available connectors...`);
+
+  logRequest(connectorEndpointBaseUrl);
+
   const res = await fetch(connectorEndpointBaseUrl, {
     headers: {
       Authorization: token,

--- a/src/connector-cli/src/core/command.ts
+++ b/src/connector-cli/src/core/command.ts
@@ -1,18 +1,16 @@
 import chalk from 'chalk';
 import { program } from 'commander';
 import version from '../../package.json';
+import { checkDryRunExecution, isDryRun } from './dry-run';
 import { enableVerboseLogging, info, verbose } from './logger';
-import { ExecutionError } from './types';
-
-export const supportedDryRunCommands = ['set-auth'];
 
 export function startCommand(command: string, options: any) {
   if (program.opts().verbose) {
     enableVerboseLogging();
   }
 
-  if (isDryRun() && !supportedDryRunCommands.includes(command)) {
-    throw new ExecutionError('Unsupported argument "--dry-run"');
+  if (isDryRun()) {
+    checkDryRunExecution(command);
   }
   info(`connector-cli v${version.version}`);
   verbose(
@@ -20,8 +18,4 @@ export function startCommand(command: string, options: any) {
       options
     )}`
   );
-}
-
-export function isDryRun() {
-  return !!program.opts().dryRun;
 }

--- a/src/connector-cli/src/core/dry-run.ts
+++ b/src/connector-cli/src/core/dry-run.ts
@@ -1,0 +1,34 @@
+import { program } from 'commander';
+
+import { ExecutionError } from './types';
+
+export const supportedDryRunCommands = ['set-auth', 'publish'];
+
+export function isDryRun() {
+  return !!readDryRunOption() || !!readDryRunOutOption();
+}
+
+export function isDryRunToConsole() {
+  return !!readDryRunOption();
+}
+
+export function isDryRunToFile() {
+  return !!readDryRunOutOption();
+}
+
+export function readDryRunOption() {
+  return program.opts().dryRun;
+}
+
+export function readDryRunOutOption() {
+  return program.opts().dryRunOut;
+}
+
+export function checkDryRunExecution(command: string) {
+  const dryRun = readDryRunOption();
+  if (!supportedDryRunCommands.includes(command)) {
+    throw new ExecutionError(
+      `Unsupported argument "${dryRun ? '--dry-run' : '--dry-run-out'}"`
+    );
+  }
+}

--- a/src/connector-cli/src/core/index.ts
+++ b/src/connector-cli/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './command';
 export * from './connector-config';
+export * from './dry-run';
 export * from './error-handling';
 export * from './logger';
 export * from './read-access-token';

--- a/src/connector-cli/src/core/logger.ts
+++ b/src/connector-cli/src/core/logger.ts
@@ -1,4 +1,13 @@
 import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+import {
+  isDryRun,
+  isDryRunToConsole,
+  isDryRunToFile,
+  readDryRunOutOption,
+} from './dry-run';
+import { ExecutionError } from './types';
 
 const startTime = Date.now();
 let verboseEnabled: boolean = false;
@@ -19,7 +28,10 @@ export function errorNoColor(arg0: string) {
 export function success(arg0: string, data: Record<string, unknown>): void;
 export function success(arg0: string): void;
 export function success(arg0: string, data?: Record<string, unknown>) {
-  const message = data ? `${arg0}\n${JSON.stringify(data)}` : arg0;
+  const prefix = isDryRun() ? '[Dry-run]: ' : '';
+  const message = data
+    ? `${prefix}${arg0}\n${JSON.stringify(data)}`
+    : prefix + arg0;
   console.info(chalk.green(formatMessage(message)));
 }
 
@@ -34,6 +46,42 @@ export function error(arg0: string) {
 export function verbose(arg0: string) {
   if (verboseEnabled) {
     info(arg0);
+  }
+}
+
+export function logRequest(requestUrl: string, payload?: object) {
+  const msg = `Sending HTTP request:\n"requestURL": ${requestUrl}\n ${
+    payload ? 'requestPayload' + JSON.stringify(payload, null, 2) : ''
+  }`;
+
+  if (isDryRun()) {
+    logDryRunRequest(msg, requestUrl, payload);
+  } else {
+    verbose(msg);
+  }
+}
+
+function logDryRunRequest(
+  msg: string,
+  requestUrl: string,
+  requestPayload?: object
+) {
+  if (isDryRunToConsole()) {
+    info(msg);
+  } else if (isDryRunToFile()) {
+    const dryRunOut = readDryRunOutOption();
+    const out = path.resolve(dryRunOut);
+    if (!out.endsWith('.json')) {
+      throw new ExecutionError(
+        'Invalid  output file type. You should provide JSON file for results, i.e. "./out.json"'
+      );
+    }
+    info(`Writing result to file: "${out}"...`);
+    fs.writeFileSync(
+      out,
+      JSON.stringify({ requestUrl, requestPayload }, null, 2),
+      'utf-8'
+    );
   }
 }
 

--- a/src/connector-cli/src/index.ts
+++ b/src/connector-cli/src/index.ts
@@ -23,11 +23,17 @@ function main() {
   program
     .name('connector-cli')
     .version(info.version, '-v, --version')
-    .description('Tool to manage connector build, test and deploy process')
+    .description("Tool to manage connector's build, test and deploy process")
     .option('--verbose', 'Enable verbose logging')
     .option(
       '--dry-run [dryRun]',
-      `Log action result instead of real HTTP request. Supported commands: ${supportedDryRunCommands.join(
+      `Log to console the command\'s result instead of real HTTP request. Supported commands: ${supportedDryRunCommands.join(
+        ', '
+      )}`
+    )
+    .option(
+      '--dry-run-out [dryRunOut]',
+      `Log to JSON file the command\'s result instead of real HTTP request. Supported commands: ${supportedDryRunCommands.join(
         ', '
       )}`
     );
@@ -159,7 +165,7 @@ function main() {
         .choices(Object.values(Tenant))
         .default(Tenant.Prod)
     )
-    .action(runLogin);
+    .action(withErrorHandlerAction(runLogin));
 
   program
     .command('set-auth')


### PR DESCRIPTION
In addition to the regular `--dry-run` that outputs result into console, from now on we would have a possibility to output command results to local JSON file too, using new `--dry-run-out` option

In context of this ticket the whole concept of dryRun mode was improved too  - we don't need valid token anymore to call commands in this mode, since no real HTTP call is happening 

Closes https://github.com/chili-publish/studio-connector-framework/issues/24