### PR TITLE
[Feat][WRS-2398] Add runtime option "rootPath" for AEM connector

### DIFF
--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -303,7 +303,7 @@ export default class MyConnector implements Media.MediaConnector {
     }
 
     // If id fetch the detail object and place it in the response
-    if (detailId) {
+    if (detailId && options.collection === null) {
       return this.detail(detailId, context).then((data) => {
         return {
           pageSize: 1,

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -100,6 +100,7 @@ class AEMTransformer {
   static assetToMedia(
     item: AemEntry,
     neededRenditions: string[],
+    rootPath: string,
     path: string = item['jcr:path']
   ): Media.Media {
     if (
@@ -107,7 +108,7 @@ class AEMTransformer {
     ) {
       const pathSplit = item['jcr:path'].split('/');
       const folderName = pathSplit.pop();
-      const relativePath = item['jcr:path'].replace('/content/dam', '');
+      const relativePath = item['jcr:path'].replace(rootPath, '');
       return {
         id: path,
         name: folderName,
@@ -139,11 +140,12 @@ class AEMTransformer {
   static assetToMediaDetail(
     data: AemEntry,
     neededRenditions: string[],
-    path: string
+    path: string,
+    rootPath: string
   ): Media.MediaDetail {
     const metadata = data['jcr:content']['metadata'];
     return {
-      ...this.assetToMedia(data, neededRenditions, path),
+      ...this.assetToMedia(data, neededRenditions, rootPath, path),
       height: metadata['tiff:ImageLength'],
       width: metadata['tiff:ImageWidth'],
       metaData: this.getMetaDataObject(metadata),
@@ -241,6 +243,14 @@ export default class MyConnector implements Media.MediaConnector {
     ];
   }
 
+  private get rootPath() {
+    const rootPath = this.runtime.options['rootPath'] as string | undefined;
+    if (rootPath) {
+      return rootPath.endsWith('/') ? rootPath.slice(0, -1) : rootPath;
+    }
+    return '/content/dam';
+  }
+
   query(
     options: Connector.QueryOptions,
     context: Connector.Dictionary
@@ -309,19 +319,18 @@ export default class MyConnector implements Media.MediaConnector {
 
     // Only flat when not searching
     let isFlat = !fulltext.length && showFolders;
-    let path = (context.path as string) || '/content/dam';
 
-    // The Home is added to path when you copy it in the studio so remove here
-    if (path.startsWith('Home/content/dam')) {
-      path = path.replace('Home/content/dam', '/content/dam');
+    const contextPath = context.path as string;
+    if (contextPath && contextPath.length < this.rootPath.length) {
+      throw new Error(
+        `The provided "path" (${contextPath}) is invalid. It cannot exceed the directory level of the specified root path (${this.rootPath}).`
+      );
     }
-    // when the collection starts with /content/dam we know that the user clicked on folder
-    if (
-      options.collection &&
-      options.collection.length &&
-      options.collection !== '/'
-    ) {
-      path = `/content/dam${options.collection}`;
+    let path = (context.path as string) || this.rootPath;
+
+    // when there is a collection other than root, we know that user clicks on folder item
+    if (options.collection?.length && options.collection !== '/') {
+      path = `${this.rootPath}${options.collection}`;
     }
     // Otherwise we do a query call
 
@@ -344,7 +353,7 @@ export default class MyConnector implements Media.MediaConnector {
             ? {
                 '1_group.1_group.type': 'sling:Folder',
                 '1_group.2_group.property': 'jcr:path',
-                '1_group.2_group.property.value': '/content/dam/appdata',
+                '1_group.2_group.property.value': `${this.rootPath}/appdata`,
                 '1_group.2_group.property.operation': 'unequals',
               }
             : {}),
@@ -371,7 +380,8 @@ export default class MyConnector implements Media.MediaConnector {
       const formattedData = data.hits.map((item) => {
         const data = AEMTransformer.assetToMedia(
           item,
-          Object.values(this.aemRenditions)
+          Object.values(this.aemRenditions),
+          this.rootPath
         );
         return data;
       });
@@ -393,7 +403,8 @@ export default class MyConnector implements Media.MediaConnector {
       const detail = AEMTransformer.assetToMediaDetail(
         data,
         Object.values(this.aemRenditions),
-        path
+        path,
+        this.rootPath
       );
       return detail;
     });

--- a/src/connectors/adobe-experience-manager/package.json
+++ b/src/connectors/adobe-experience-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adobe-experience-manager",
   "description": "AEM Chili Publish connector",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "author": {
     "name": "CHILI publish",
     "email": "info@chili-publish.com",
@@ -13,6 +13,7 @@
     "iconUrl": "https://studio-cdn.chiligrafx.com/shared/demo-connectors/aem_logo.svg",
     "options": {
       "BASE_URL": null,
+      "rootPath": "/content/dam",
       "renditionOverrides": ""
     },
     "supportedAuth": [

--- a/src/connectors/adobe-experience-manager/readme.md
+++ b/src/connectors/adobe-experience-manager/readme.md
@@ -43,7 +43,7 @@ connector-cli publish \
 
 ## Root path
 
-By default connector uses `/content/dam` as root path of requested assets if you wanna be more specific or don't need the all available assets from your AEM instance, you can change the defaults using runtime option `rootPath`
+By default connector uses `/content/dam` as root path of requested assets. If you want to be more specific or don't need the all available assets from your AEM instance, you can change the defaults using runtime option `rootPath`
 
 ```
 connector-cli publish \

--- a/src/connectors/adobe-experience-manager/readme.md
+++ b/src/connectors/adobe-experience-manager/readme.md
@@ -41,6 +41,21 @@ connector-cli publish \
     --connectorId={CONNECTOR_ID}
 ```
 
+## Root path
+
+By default connector uses `/content/dam` as root path of requested assets if you wanna be more specific or don't need the all available assets from your AEM instance, you can change the defaults using runtime option `rootPath`
+
+```
+connector-cli publish \
+    -e {ENVIRONMENT} \
+    -b https://{ENVIRONMENT}.chili-publish.online/grafx \
+    -n "Adobe Experience Manager" \
+    --proxyOption.allowedDomains "*.adobeaemcloud.com" \
+    --runtimeOption="BASE_URL=https://{AUTHOR_ENVIRONMENT}.adobeaemcloud.com/" \
+    --runtimeOption="rootPath=/content/dam/sub-folder/sub-sub-folder" \
+    --connectorId={CONNECTOR_ID}
+```
+
 ## Docs Querybuilder
 
 We use the querybuilder to load the different assets + folders you can extend these query by the Search Query Field


### PR DESCRIPTION
With this option if it's configured, you can limit the requested assets for your connector if you don't need to work with the whole AEM instance resources