### PR TITLE
[Fix] Support of native engine formats for output - PNG/JPEG/PDF

### DIFF
--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -515,7 +515,7 @@ export default class MyConnector implements Media.MediaConnector {
   private getCorrectRendition(
     availableRenditions: string[],
     previewType: Media.DownloadType,
-    isSupportedFormat?: boolean
+    isNativelySupportedFormat?: boolean
   ) {
     const getRendition = (renditionType: AemRendition) => {
       let rendition = this.aemRenditions[renditionType];
@@ -540,7 +540,7 @@ export default class MyConnector implements Media.MediaConnector {
       return getRendition(AemRendition.MediumRes);
     } else if (previewType === 'highres') {
       return getRendition(AemRendition.HighRes);
-    } else if (previewType === 'fullres' && !isSupportedFormat) {
+    } else if (previewType === 'fullres' && !isNativelySupportedFormat) {
       return getRendition(AemRendition.Pdf);
     }
     // Original asset

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -348,6 +348,7 @@ export default class MyConnector implements Media.MediaConnector {
     // Otherwise we do a query call
 
     return this.aemQueryCall(
+      context['matchExactly'] === true,
       {
         fulltext: fulltext,
         path: path,
@@ -497,6 +498,11 @@ export default class MyConnector implements Media.MediaConnector {
         type: 'text',
       },
       {
+        name: 'matchExactly',
+        displayName: 'Match Exactly - when searching, the search name must be an exact match',
+        type: 'boolean',
+      },
+      {
         name: 'includeSubfolders',
         displayName: 'Include subfolders',
         type: 'boolean',
@@ -548,6 +554,7 @@ export default class MyConnector implements Media.MediaConnector {
   }
 
   private async aemQueryCall(
+    matchExactly: boolean,
     queryParams: Record<string, string | boolean | number | any[]>,
     groups: Record<string, string | number | boolean | any[]>[],
     {
@@ -574,6 +581,9 @@ export default class MyConnector implements Media.MediaConnector {
       sortName,
       sortDir,
     };
+    if (matchExactly) {
+      allQuery['nodename'] = queryParams.fulltext;
+    }
     if (neededProperties) {
       allQuery['p.hits'] = 'selective';
       allQuery['p.properties'] = neededProperties.join(' ');

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -35,7 +35,7 @@ export type AemRenditions = {
 export interface InternalAemId {
   availableRenditions: string[];
   isImage?: boolean; // Leaved for backward compatibility for used assets. TODO: Should be removed before releasing the connector
-  isNativelySupportedFormat?: boolean; // PNG/JPG/PDF
+  isNativelySupportedFormat?: boolean; // PNG/JPEG/PDF
   path: string;
 }
 

--- a/src/connectors/adobe-experience-manager/package.json
+++ b/src/connectors/adobe-experience-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adobe-experience-manager",
   "description": "AEM Chili Publish connector",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "author": {
     "name": "CHILI publish",
     "email": "info@chili-publish.com",

--- a/src/connectors/adobe-experience-manager/readme.md
+++ b/src/connectors/adobe-experience-manager/readme.md
@@ -10,7 +10,7 @@ connector-cli publish \
     -b https://{ENVIRONMENT}.chili-publish.online/grafx \
     -n "Adobe Experience Manager" \
     --proxyOption.allowedDomains "*.adobeaemcloud.com" \
-    --runtimeOption="BASE_URL=https://{AUTHOR_ENVIRONMENT}.adobeaemcloud.com/" \
+    -ro BASE_URL="https://{AUTHOR_ENVIRONMENT}.adobeaemcloud.com/" \
     --connectorId={CONNECTOR_ID}
 ```
 
@@ -28,22 +28,23 @@ For Aem we use the Renditions specified in the AEM platform, These renditions ar
 }
 ```
 
-You can override them by adding them to the runtime options by example you can replace them thumbnail with "eam.customthumb.png" by publishing with this runtime command
+You can override them by adding the `renditionOverrides` runtime option. For example, you can replace them thumbnail with "eam.customthumb.png" by publishing with this runtime command
 
 ```
 connector-cli publish \
-    -e {ENVIRONMENT} \
-    -b https://{ENVIRONMENT}.chili-publish.online/grafx \
-    -n "Adobe Experience Manager" \
-    --proxyOption.allowedDomains "*.adobeaemcloud.com" \
-    --runtimeOption="BASE_URL=https://{AUTHOR_ENVIRONMENT}.adobeaemcloud.com/" \
-    --runtimeOption="renditionOverrides={\"thumbnail\": \"eam.customthumb.png\"}" \
-    --connectorId={CONNECTOR_ID}
+    ...
+    -ro renditionOverrides="{\"thumbnail\": \"eam.customthumb.png\"}"
 ```
 
 ## Root path
 
 By default connector uses `/content/dam` as root path of requested assets. If you want to be more specific or don't need the all available assets from your AEM instance, you can change the defaults using runtime option `rootPath`
+
+```
+connector-cli publish \
+    ...
+    -ro rootPath="/content/dam/sub-folder/sub-sub-folder"
+```
 
 ## Logs
 
@@ -51,13 +52,8 @@ If you encounter any problems during the connector's operation, you can enable d
 
 ```
 connector-cli publish \
-    -e {ENVIRONMENT} \
-    -b https://{ENVIRONMENT}.chili-publish.online/grafx \
-    -n "Adobe Experience Manager" \
-    --proxyOption.allowedDomains "*.adobeaemcloud.com" \
-    --runtimeOption="BASE_URL=https://{AUTHOR_ENVIRONMENT}.adobeaemcloud.com/" \
-    --runtimeOption="rootPath=/content/dam/sub-folder/sub-sub-folder" \
-    --connectorId={CONNECTOR_ID}
+    ...
+    -ro logEnabled="true"
 ```
 
 ## Docs Querybuilder


### PR DESCRIPTION
In context of this PR full support of native PDF assets was added when `intent === "print"` for output generation with Pdf  and fullRes fallback renditions for other type of assets other than natively supported

For `intent !== "print"` we use original image if it has supported type (PNG / JPEG) or fallback to fullResfallback rendition

It also fix https://chilipublishintranet.atlassian.net/browse/WRS-2327