### PR TITLE
[Fix] - AEM Search Inaccuracy 

### DIFF
--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -348,7 +348,7 @@ export default class MyConnector implements Media.MediaConnector {
     // Otherwise we do a query call
 
     return this.aemQueryCall(
-      context["matchExactly"] === true,
+      context['matchExactly'] === true,
       {
         fulltext: fulltext,
         path: path,

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -348,6 +348,7 @@ export default class MyConnector implements Media.MediaConnector {
     // Otherwise we do a query call
 
     return this.aemQueryCall(
+      context["matchExactly"] === true,
       {
         fulltext: fulltext,
         path: path,
@@ -497,6 +498,11 @@ export default class MyConnector implements Media.MediaConnector {
         type: 'text',
       },
       {
+        name: 'matchExactly',
+        displayName: 'Match Exactly - when searching, the search name must be an exact match',
+        type: 'boolean',
+      },
+      {
         name: 'includeSubfolders',
         displayName: 'Include subfolders',
         type: 'boolean',
@@ -548,6 +554,7 @@ export default class MyConnector implements Media.MediaConnector {
   }
 
   private async aemQueryCall(
+    matchExactly: boolean,
     queryParams: Record<string, string | boolean | number | any[]>,
     groups: Record<string, string | number | boolean | any[]>[],
     {
@@ -574,6 +581,9 @@ export default class MyConnector implements Media.MediaConnector {
       sortName,
       sortDir,
     };
+    if (matchExactly) {
+      allQuery['nodename'] = queryParams.fulltext;
+    }
     if (neededProperties) {
       allQuery['p.hits'] = 'selective';
       allQuery['p.properties'] = neededProperties.join(' ');


### PR DESCRIPTION
**Problem:**

When searching for specific files in Adobe Experience Manager (AEM), particularly when the filename is well-defined, AEM sometimes exhibits unexpected behavior.  Specifically, when querying for a file like `"file-name-cool.pdf"`, AEM may incorrectly return results that include other files with similar names, such as `"file-name-warm.pdf"` or `"file-name-hot.pdf"`. This occurs even when those other files shouldn't logically match the precise search term.

**Example:**

Consider a directory containing these files:

*   `file-name-warm.pdf`
*   `file-name-cool.pdf`
*   `file-name-hot.pdf`

A search for `"file-name-cool.pdf"` should *only* return `file-name-cool.pdf`. However, AEM might mistakenly include `file-name-warm.pdf` or `file-name-hot.pdf` in the results.  This unexpected behavior can lead to significant problems in templates that rely on accurate file retrieval.

**Solution: The `matchExactly` Setting**

To address this issue, a new setting, `matchExactly`, has been introduced.  When enabled, this setting forces AEM to perform a precise, character-by-character match against the search term.

**Trade-off:**

Enabling `matchExactly` enforces strict matching. This means that a broader search like `"file-name"` will now return *zero* results. This is because the search term must precisely match the entire filename.

**Business Case and Why This Matters:**

The primary use case for `matchExactly` is when interacting with AEM connector via template actions.

Imagine a scenario where you have a dropdown menu offering temperature options: "warm," "cool," and "hot." When a user selects an option (e.g., "cool"), an action is triggered that searches AEM for a file using a filename constructed dynamically: `"file-name-${temperature}"` (e.g., `"file-name-cool.pdf"`).

Without `matchExactly`, AEM might return the *wrong* file (e.g., `"file-name-warm.pdf"`) even though the user specifically selected "cool."  This could lead to serving incorrect content, broken workflows, and a poor user experience.

**In summary:**

*   **The Problem:** Inaccurate AEM search results, especially when querying for specific filenames.
*   **The Solution:** The `matchExactly` setting ensures precise filename matching.
*   **The Benefit:** Prevents AEM from randomly returning incorrect files, ensuring data integrity and a predictable user experience, particularly in automated workflows.
*   **The Caveat:** Requires exact filename matches, so broader searches will not return results.  Careful consideration is needed to balance the need for accuracy with the potential for broader search functionality.