### PR TITLE
Use AEM asset path as ID instead of JSON structure

### DIFF
--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -290,6 +290,7 @@ export default class MyConnector implements Media.MediaConnector {
         }
       }
       // Create the full path string, but check if it's still an old ID format
+      // AEM does not support folders with " as a character in the name, so impossible for the path {" to exist
       const fullPath = filter.startsWith('{"')
         ? JSON.parse(filter).path
         : contextPath + filter;
@@ -409,7 +410,7 @@ export default class MyConnector implements Media.MediaConnector {
   }
 
   async download(
-    path: string,
+    id: string,
     previewType: Media.DownloadType,
     intent: Media.DownloadIntent,
     context: Connector.Dictionary
@@ -417,7 +418,7 @@ export default class MyConnector implements Media.MediaConnector {
     this.log(
       `[Download params]:\n${JSON.stringify(
         {
-          path,
+          id,
           previewType,
           intent,
         },
@@ -425,6 +426,8 @@ export default class MyConnector implements Media.MediaConnector {
         2
       )}`
     );
+
+    const path = id;
 
     // Fetch asset metadata using the pattern {baseUrl}{id}-1.json
     const metadataResult = await this.aemResourceCall<AemEntry>(

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -279,9 +279,8 @@ export default class MyConnector implements Media.MediaConnector {
     const filter = options.filter[0];
     // Query before download
     if (!options.collection) {
-
-      let contextPath = "";
-      if (context.path && typeof context.path == "string") {
+      let contextPath = '';
+      if (context.path && typeof context.path == 'string') {
         contextPath = context.path;
         if (!contextPath.startsWith('/')) {
           contextPath = '/' + contextPath;
@@ -467,7 +466,8 @@ export default class MyConnector implements Media.MediaConnector {
       })
       .then((result) => {
         if (!result.ok) {
-          throw new Error(
+          throw new ConnectorHttpError(
+            result.status,
             `AEM: Download failed ${result.status} - ${result.statusText}`
           );
         }
@@ -628,7 +628,10 @@ export default class MyConnector implements Media.MediaConnector {
     });
 
     if (!res.ok) {
-      throw new Error(`AEM: Query failed ${res.status} - ${res.statusText}`);
+      throw new ConnectorHttpError(
+        res.status,
+        `AEM: Query failed ${res.status} - ${res.statusText}`
+      );
     }
     return JSON.parse(res.text) as any;
   }
@@ -648,7 +651,10 @@ export default class MyConnector implements Media.MediaConnector {
     });
 
     if (!res.ok) {
-      throw new Error(`AEM: Query failed ${res.status} - ${res.statusText}`);
+      throw new ConnectorHttpError(
+        res.status,
+        `AEM: Query failed ${res.status} - ${res.statusText}`
+      );
     }
     return JSON.parse(res.text) as Return;
   }

--- a/src/connectors/adobe-experience-manager/connector.ts
+++ b/src/connectors/adobe-experience-manager/connector.ts
@@ -32,12 +32,6 @@ export type AemRenditions = {
   [key in AemRendition]: string | null;
 };
 
-export interface InternalAemId {
-  availableRenditions: string[];
-  format?: string;
-  path: string;
-}
-
 class AEMTransformer {
   static neededProperties = [
     'jcr:path',
@@ -61,31 +55,21 @@ class AEMTransformer {
     });
   };
 
-  // Add path + renditions to the id
+  // Return simple path string as ID
   static getIdFromItem = (
     item: AemEntry,
-    neededRenditions: string[],
+    _neededRenditions: string[],
     path: string = item['jcr:path']
   ) => {
-    var format = item['jcr:content']['metadata']['dc:format'];
-
-    return JSON.stringify({
-      format,
-      availableRenditions: this.getAvailableRenditions(item, neededRenditions),
-      path: path,
-    } as InternalAemId);
+    return path;
   };
   // When fetching a collection we only have path strings so create from path media object
   static resourcePathToMedia(path: string): Media.Media {
-    const id = JSON.stringify({
-      path: path,
-    });
-
     const name = path.split('/').pop();
     const extension = name.split('.').pop();
 
     return {
-      id,
+      id: path,
       name: name,
       type: 0,
       // TODO: to be defined
@@ -255,7 +239,7 @@ export default class MyConnector implements Media.MediaConnector {
     return '/content/dam';
   }
 
-  query(
+  async query(
     options: Connector.QueryOptions,
     context: Connector.Dictionary
   ): Promise<Media.MediaPage> {
@@ -266,6 +250,8 @@ export default class MyConnector implements Media.MediaConnector {
     const pageSize = options.pageSize || 20;
     // When collection we fetch the collection resources and create media objects from paths
     const collection = context.collection as string | undefined;
+    // This is never called because when is there a situation where collection is ""
+    // Collection is either undefined or a path with "/"
     if (collection && collection.length) {
       return this.aemResourceCall(`${collection}.1.json`).then((data) => {
         if (data['sling:members'] && data['sling:members']['sling:resources']) {
@@ -290,38 +276,33 @@ export default class MyConnector implements Media.MediaConnector {
       });
     }
 
-    // check if filters is not id
-    let fulltext = '';
-    let detailId: string;
-    const filters = options.filter;
-    if (filters && filters.length && filters[0].length) {
-      // Check if id is in filterss
-      try {
-        // If it can be parsed we know that its an id
-        var parsed = JSON.parse(filters[0]) as InternalAemId;
-        if (parsed.path) {
-          detailId = filters[0];
-        } else {
-          fulltext = filters[0];
+    const filter = options.filter[0];
+    // Query before download
+    if (!options.collection) {
+
+      let contextPath = "";
+      if (context.path && typeof context.path == "string") {
+        contextPath = context.path;
+        if (!contextPath.startsWith('/')) {
+          contextPath = '/' + contextPath;
         }
-      } catch (error) {
-        fulltext = filters[0];
+        if (!contextPath.endsWith('/')) {
+          contextPath = contextPath + '/';
+        }
       }
+
+      const path = contextPath + filter;
+      this.log(`Query before download case for: ${path}`);
+      return {
+        pageSize: 1,
+        data: [AEMTransformer.resourcePathToMedia(path)],
+        links: {
+          nextPage: '',
+        },
+      };
     }
 
-    // If id fetch the detail object and place it in the response
-    if (detailId && !options.collection) {
-      this.log(`Query before download case for: ${detailId}`);
-      return this.detail(detailId, context).then((data) => {
-        return {
-          pageSize: 1,
-          data: [data],
-          links: {
-            nextPage: '',
-          },
-        };
-      });
-    }
+    const fulltext = filter;
     // Don't show the folders when its set via configuration
     let showFolders = context.includeSubfolders ?? true;
 
@@ -410,7 +391,7 @@ export default class MyConnector implements Media.MediaConnector {
     context: Connector.Dictionary
   ): Promise<Media.MediaDetail> {
     this.log(`[Detail params]:\n ${id}`);
-    const { path } = JSON.parse(id);
+    const path = id; // ID is now directly the path string
     const detailResult = await this.aemResourceCall<AemEntry>(
       `${path}.-1.json`
     ).then((data) => {
@@ -426,7 +407,7 @@ export default class MyConnector implements Media.MediaConnector {
     return detailResult;
   }
 
-  download(
+  async download(
     id: string,
     previewType: Media.DownloadType,
     intent: Media.DownloadIntent,
@@ -443,9 +424,22 @@ export default class MyConnector implements Media.MediaConnector {
         2
       )}`
     );
-    const { availableRenditions, path, format } = JSON.parse(
-      id
-    ) as InternalAemId;
+
+    // Use ID directly as the path string, but check if it's still an old ID format
+    const path = id.includes('{"f') ? JSON.parse(id).path : id;
+
+    // Fetch asset metadata using the pattern {baseUrl}{id}-1.json
+    const metadataResult = await this.aemResourceCall<AemEntry>(
+      `${path}.-1.json`
+    );
+
+    // Extract available renditions and format from the metadata
+    const availableRenditions = AEMTransformer.getAvailableRenditions(
+      metadataResult,
+      Object.values(this.aemRenditions)
+    );
+    const format = metadataResult['jcr:content']['metadata']['dc:format'];
+
     let downloadPath = path;
     if (downloadPath.startsWith('/')) {
       downloadPath = path.substring(1);
@@ -473,8 +467,7 @@ export default class MyConnector implements Media.MediaConnector {
       })
       .then((result) => {
         if (!result.ok) {
-          throw new ConnectorHttpError(
-            result.status,
+          throw new Error(
             `AEM: Download failed ${result.status} - ${result.statusText}`
           );
         }
@@ -635,10 +628,7 @@ export default class MyConnector implements Media.MediaConnector {
     });
 
     if (!res.ok) {
-      throw new ConnectorHttpError(
-        res.status,
-        `AEM: Query failed ${res.status} - ${res.statusText}`
-      );
+      throw new Error(`AEM: Query failed ${res.status} - ${res.statusText}`);
     }
     return JSON.parse(res.text) as any;
   }
@@ -658,10 +648,7 @@ export default class MyConnector implements Media.MediaConnector {
     });
 
     if (!res.ok) {
-      throw new ConnectorHttpError(
-        res.status,
-        `AEM: Query failed ${res.status} - ${res.statusText}`
-      );
+      throw new Error(`AEM: Query failed ${res.status} - ${res.statusText}`);
     }
     return JSON.parse(res.text) as Return;
   }

--- a/src/connectors/adobe-experience-manager/package.json
+++ b/src/connectors/adobe-experience-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adobe-experience-manager",
   "description": "AEM Chili Publish connector",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "author": {
     "name": "CHILI publish",
     "email": "info@chili-publish.com",


### PR DESCRIPTION
# Use AEM asset path as ID instead of JSON structure

## Overview
This PR addresses the ID management issues identified in [MAIN-1390](https://chilipublishintranet.atlassian.net/browse/MAIN-1390) by removing the `InternalAEMId` interface that was abusing the ID system to solve metadata problems.

The PR adds an extra API call in the `download` function but removes the original query call, so it's net-zero. I've also implemented Adobe's advice to call files directly via the AEM API instead of querying the folder first. (See [MAIN-1320](https://chilipublishintranet.atlassian.net/browse/MAIN-1320))

There's some oddity with mixing async/await and `.then()` patterns, plus naming conventions that don't match all changes, but I kept things close to the original code for easier review. I chose this approach over major changes because the AEM connector needs a broader reevaluation and refactor, which I'll discuss in [MAIN-1415](https://chilipublishintranet.atlassian.net/browse/MAIN-1415).


## Key Changes

### 🔧 ID Format Simplification
- **Removed** `InternalAemId` JSON structure 
- **Changed** AEM asset IDs to use simple path strings instead of JSON objects
- **Updated** `AEMTransformer.getIdFromItem` to return path directly
- **Maintained** backward compatibility in `download` method for existing JSON IDs

### ⚡ Download Workflow Optimization  
- **Implemented** Adobe's recommendation to call files directly via AEM API
- **Replaced** folder query to instead go straight to file download with the path
- **Net zero** API call impact: removes original query call API call to folder, adds one in download function as recommend by Adobe

### 🧹 Code Improvements
- **Removed** unused `detailId` variable and parsing logic
- **Mixed** async/await with existing `.then()` patterns for minimal code disruption pending a potential full refactor - see [MAIN-1415](https://chilipublishintranet.atlassian.net/browse/MAIN-1415) 

## Breaking Changes
⚠️ **BREAKING CHANGE:** AEM asset IDs now use path strings instead of JSON objects. Backward compatibility is maintained in the download method, but manual crop overrides will be impacted.

## Technical Notes
- API call count remains equal due to call redistribution
- Code style intentionally kept close to original for easier review
- Mixed async patterns preserved to minimize changes and keep easy readability

## Related Issues
- Fixes: [MAIN-1390](https://chilipublishintranet.atlassian.net/browse/MAIN-1390)
- Implements: [MAIN-1320](https://chilipublishintranet.atlassian.net/browse/MAIN-1320)
- Follow-up: [MAIN-1415](https://chilipublishintranet.atlassian.net/browse/MAIN-1415) - AEM connector refactor evaluation

## Testing
- [x ] Backward compatibility with existing JSON IDs
- [x ] Direct file download functionality  
- [x] Query-before-download scenarios


[MAIN-1390]: https://chilipublishintranet.atlassian.net/browse/MAIN-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAIN-1415]: https://chilipublishintranet.atlassian.net/browse/MAIN-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAIN-1415]: https://chilipublishintranet.atlassian.net/browse/MAIN-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAIN-1320]: https://chilipublishintranet.atlassian.net/browse/MAIN-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ