### PR TITLE
update kadanza connector to use asset title instead of name

### DIFF
--- a/src/connectors/kadanza/CHANGELOG.md
+++ b/src/connectors/kadanza/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Releases
 
+## 1.0.4
+
+- Use asset `title` instead of `name` in the media selection panel
+
+## 1.0.3
+
+- Add `/cdn` prefix to download URLs to avoid 301 redirects
+
 ## 1.0.2
 - Align search query to the supported file types 
 

--- a/src/connectors/kadanza/connector.ts
+++ b/src/connectors/kadanza/connector.ts
@@ -307,7 +307,7 @@ export default class DamConnector implements Media.MediaConnector {
     return {
       // We save all information required for 'download` under id to avoid details call
       id: JSON.stringify(assetId),
-      name: damMedia.name,
+      name: damMedia.title,
       relativePath: 'Media',
       type: 0,
       metaData: this._getMetadataFromDamMedia(damMedia, customMetadata),

--- a/src/connectors/kadanza/package.json
+++ b/src/connectors/kadanza/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kadanza",
   "description": "Kadanza",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Kadanza",
     "email": "hello@kadanza.com",


### PR DESCRIPTION
- Use 'title' instead of 'name' for asset display in the media selection panel
- Bump version to 1.0.4