### PR TITLE
[Feat][WRS-3132] Install global sleep in connector CLI debugger

### DIFF
--- a/src/connector-cli/debugger/src/App.tsx
+++ b/src/connector-cli/debugger/src/App.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './Components/Sidebar';
 import { useConnectorSettings } from './core/useConnectorSettings';
 import { initRuntime } from './Helpers/ConnectorRuntime';
 import { initRuntimeErrors } from './Helpers/ConnectorRuntime/ConnectorHttpError';
+import { initRuntimeSleep } from './Helpers/ConnectorRuntime/sleep';
 import { ComplexParameter, DataModel } from './Helpers/DataModel';
 import { Models } from './Helpers/Models';
 
@@ -56,6 +57,7 @@ function App() {
 
   useEffect(() => {
     initRuntimeErrors();
+    initRuntimeSleep();
   }, []);
 
   useEffect(() => {

--- a/src/connector-cli/debugger/src/Helpers/ConnectorRuntime/sleep.ts
+++ b/src/connector-cli/debugger/src/Helpers/ConnectorRuntime/sleep.ts
@@ -1,0 +1,7 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function initRuntimeSleep() {
+  (window as any)['sleep'] = sleep;
+}


### PR DESCRIPTION
This PR
- Installs a global `sleep(ms)` helper on `window` in the Connector CLI debugger (same pattern as `ConnectorHttpError`), so connectors using `await sleep(...)` work under debug.

## Related tickets

- [WRS-3132](https://chilipublishintranet.atlassian.net/browse/WRS-3132)

## Notes

- Local `declare function sleep` in `grafx-media-example` is intentionally kept until `@chili-publish/studio-connectors` with the `sleep` global typing is released to PRD and consumed by the example.

[WRS-3132]: https://chilipublishintranet.atlassian.net/browse/WRS-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ