### PR TITLE
chore: 1.12.1 connector cli release

### DIFF
--- a/src/connector-cli/package.json
+++ b/src/connector-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chili-publish/connector-cli",
-  "version": "1.12.1-rc.2",
+  "version": "1.12.1",
   "main": "out/src/index.js",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
Release `@chili-publish/connector-cli` as `1.12.1`