### PR TITLE
[Fix] Sync cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "publish-all": "node scripts/publish.js"
   },
   "devDependencies": {
-    "@chili-publish/connector-cli": "^1.12.1-rc.0",
+    "@chili-publish/connector-cli": "^1.12.2-rc.0",
     "prettier": "^3.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- Sync root `devDependencies["@chili-publish/connector-cli"]` to `^1.12.2-rc.0` to match `src/connector-cli/package.json` after the 1.12.1 release merge (post-CI bump)

## Test plan
- [ ] Root dependency matches workspace package version
- [ ] `yarn install` succeeds


Made with [Cursor](https://cursor.com)