### PR TITLE
[WRS-3099] Fix connector PR validation for stacked and fork PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,23 +17,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch head branch
+      - name: Fetch PR head
         run: |
-          # Check if the PR is from a fork
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            echo "Pull request is from a fork. Fetching head branch from the fork repository."
-            git fetch https://github.com/${{ github.event.pull_request.head.repo.full_name }} \
-              ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
-          else
-            echo "Pull request is from the same repository. Fetching head branch locally."
-            git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
-          fi
+          # pull/N/head works for same-repo and fork PRs on the base repository
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          # Fail if a force-push moved pull/N/head away from the event that triggered this run
+          test "$(git rev-parse --verify 'pr-head^{commit}')" = \
+            "${{ github.event.pull_request.head.sha }}"
 
       - name: Get changed files
         id: files
         run: |
-          # Get the list of changed files as a comma-separated string
-          files=$(git diff --name-only ${{ github.event.pull_request.head.ref }} | tr '\n' ',')
+          # Three-dot diff matches the PR "Files changed" list (works for stacked bases)
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...pr-head | tr '\n' ',')
           echo "files=$files" >> $GITHUB_ENV
 
       - name: Ensure only one connector is changed
@@ -81,17 +77,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch head branch
+      - name: Fetch PR head
         run: |
-          # Check if the PR is from a fork
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            echo "Pull request is from a fork. Fetching head branch from the fork repository."
-            git fetch https://github.com/${{ github.event.pull_request.head.repo.full_name }} \
-              ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
-          else
-            echo "Pull request is from the same repository. Fetching head branch locally."
-            git fetch origin ${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.ref }}
-          fi
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          # Fail if a force-push moved pull/N/head away from the event that triggered this run
+          test "$(git rev-parse --verify 'pr-head^{commit}')" = \
+            "${{ github.event.pull_request.head.sha }}"
 
       - name: Ensure connector version is bumped
         env:
@@ -104,7 +95,7 @@ jobs:
 
           connector_name="$CONNECTOR_NAME"
           MAIN_VERSION=$(git show origin/main:src/connectors/$connector_name/package.json | jq -r .version)
-          PR_VERSION=$(git show ${{ github.event.pull_request.head.ref }}:src/connectors/$connector_name/package.json | jq -r .version)
+          PR_VERSION=$(git show pr-head:src/connectors/$connector_name/package.json | jq -r .version)
 
           echo "Comparing versions for connector '$connector_name':"
           echo "Main version: '$MAIN_VERSION'"


### PR DESCRIPTION
This PR

## Related tickets

- [WRS-3099](https://chilipublishintranet.atlassian.net/browse/WRS-3099)

Harden connector PR validation so changed-file detection and version checks work for stacked bases and fork PRs: fetch `pull/N/head`, pin to the event SHA, and use a three-dot diff against the PR base.

[WRS-3099]: https://chilipublishintranet.atlassian.net/browse/WRS-3099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ