### PR TITLE
[GRAFX-6469] Mask git push credentials in CI

### DIFF
--- a/.github/workflows/promote-cli.yml
+++ b/.github/workflows/promote-cli.yml
@@ -69,11 +69,17 @@ jobs:
           VERSION: ${{ steps.compute.outputs.version }}
           APP_TOKEN: ${{ steps.github-app-access-token.outputs.token }}
         run: |
+          echo "::add-mask::${APP_TOKEN}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/connector-cli/package.json package.json
           git commit -m "CI: promote connector-cli to ${VERSION} [skip ci]"
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" HEAD:main
+          AUTHORIZATION=$(printf 'x-access-token:%s' "${APP_TOKEN}" | base64 | tr -d '\n')
+          echo "::add-mask::${AUTHORIZATION}"
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTHORIZATION}" \
+            git push "https://github.com/${{ github.repository }}.git" HEAD:main
 
       - name: Create draft GitHub Release
         env:


### PR DESCRIPTION
This PR

## Related tickets

- [GRAFX-6469](https://chilipublishintranet.atlassian.net/browse/GRAFX-6469)

Made with [Cursor](https://cursor.com)

[GRAFX-6469]: https://chilipublishintranet.atlassian.net/browse/GRAFX-6469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ